### PR TITLE
Update 27-rotate-right-advanced-spec.js

### DIFF
--- a/test/27-rotate-right-advanced-spec.js
+++ b/test/27-rotate-right-advanced-spec.js
@@ -6,7 +6,7 @@ let arr = ['a', 'b', 'c', 'd', 'e'];
 let copy = arr
 describe("Rotate Right", function(){
     it("Should return an array where elements are shifted right num times.", function(){
-        expect(rotateRight(['a', 'b', 'c', 'd', 'e'], 2)).to.have.deep.members([ 'd', 'e', 'a', 'b', 'c' ])
+        expect(rotateRight(['a', 'b', 'c', 'd', 'e'], 2)).to.have.deep.ordered.members([ 'd', 'e', 'a', 'b', 'c' ])
     })
     it("Should return a new array and not the original array mutated.", function(){
         expect(rotateRight(arr)).to.not.equal(copy);


### PR DESCRIPTION
The test was passing for the following code:

```function rotateRight(array, num) {
    let lastPart = array.slice(0, num);
    let firstPart = array.slice(num);
    return firstPart.concat(lastPart);
}```

Which did not match the output wanted